### PR TITLE
Replace assertEquals with assertEqual

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -116,9 +116,9 @@ class ClientTest(TestCase):
     @vcr.use_cassette('fixtures/client/array_endpoints.yaml')
     def test_client_creates_wrapped_arrays(self):
         client = Client('cfexampleapi', 'b4c0n73n7fu1', content_type_cache=False)
-        self.assertEquals(str(client.content_types()), "<Array size='4' total='4' limit='100' skip='0'>")
-        self.assertEquals(str(client.entries()), "<Array size='10' total='10' limit='100' skip='0'>")
-        self.assertEquals(str(client.assets()), "<Array size='4' total='4' limit='100' skip='0'>")
+        self.assertEqual(str(client.content_types()), "<Array size='4' total='4' limit='100' skip='0'>")
+        self.assertEqual(str(client.entries()), "<Array size='10' total='10' limit='100' skip='0'>")
+        self.assertEqual(str(client.assets()), "<Array size='4' total='4' limit='100' skip='0'>")
 
     # X-Contentful-User-Agent Headers
 


### PR DESCRIPTION
`assertEquals` [was deprecated in Python 3.3](https://docs.python.org/3.3/library/unittest.html#deprecated-aliases). This function was an alias to [`assertEqual`](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase.assertEqual). More information can be found in this Stack Overflow question: ["assertEquals vs. assertEqual in python"](https://stackoverflow.com/questions/930995/assertequals-vs-assertequal-in-python).