### PR TITLE
allow retries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,6 +250,13 @@ The client constructor supports several options you may set to achieve the expec
           <td>Enables gzip response content encoding.</td>
         </tr>
         <tr>
+          <td><code>max_retries</code></td>
+          <td><code>1</code></td>
+          <td>
+            Maximum number of retries after a request failure.
+          </td>
+        </tr>
+        <tr>
           <td><code>max_rate_limit_retries</code></td>
           <td><code>1</code></td>
           <td>

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -7,7 +7,7 @@ import re
 from unittest import TestCase
 
 from requests_mock import ANY
-
+from urllib3.exceptions import MaxRetryError
 from contentful.client import Client
 from contentful.content_type_cache import ContentTypeCache
 from contentful.errors import EntryNotFoundError
@@ -198,7 +198,7 @@ class ClientTest(TestCase):
         client = Client('a22o2qgm356c', 'bfbc63cf745a037125dbcc64f716a9a0e9d091df1a79e84920b890f87a6e7ab9', environment='staging', content_type_cache=False)
         sync = client.sync({'initial': True})
 
-        self.assertEquals(sync.items[0].environment.id, 'staging')
+        self.assertEqual(sync.items[0].environment.id, 'staging')
 
     @vcr.use_cassette('fixtures/client/array_endpoints.yaml')
     def test_client_creates_wrapped_arrays(self):


### PR DESCRIPTION
We have an issue where the Content Delivery API sporadically fails.  Instead of causing our whole sync process to fail, it was helpful to allow for retries.  It's hacky, but I thought I would at least half-try to contribute.

Please let me know if this is useful and/or there are requested changes.