### PR TITLE
Fixed an `IndexError: list assignment index out of range` error in RichTextField coersion

### DIFF
--- a/contentful/content_type_field_types.py
+++ b/contentful/content_type_field_types.py
@@ -217,7 +217,7 @@ class RichTextField(BasicField):
         for node_index, coerced_node in coerced_nodes.items():
             value['content'][node_index] = coerced_node
 
-        for node_index in invalid_nodes:
+        for node_index in reversed(invalid_nodes):
             del value['content'][node_index]
 
         return value

--- a/tests/content_type_field_types_test.py
+++ b/tests/content_type_field_types_test.py
@@ -203,3 +203,41 @@ class RichTextFieldTest(TestCase):
 
         coerced = rt_field.coerce(document)
         self.assertTrue(isinstance(coerced['content'][0]['data']['target'], Link))
+
+        # with 2 embedded entries that have errors, both will be removed
+        # without a list index out of range error
+        document = {
+            "nodeType": "document",
+            "content": [{
+                "nodeType": "embedded-entry-block",
+                "nodeClass": "block",
+                "data": {
+                    "target": {
+                        "sys": {
+                            "type": "Link",
+                            "linkType": "Entry",
+                            "id": "4JJ21pcEI0QSsea20g6K6K"
+                        }
+                    }
+                }
+            }, {
+                "nodeType": "embedded-entry-block",
+                "nodeClass": "block",
+                "data": {
+                    "target": {
+                        "sys": {
+                            "type": "Link",
+                            "linkType": "Entry",
+                            "id": "4JJ21pcEI0QSsea20g6K6K"
+                        }
+                    }
+                }
+            }]
+        }
+
+        errors = [{"details": {"id": "4JJ21pcEI0QSsea20g6K6K"}}]
+
+        self.assertEqual(rt_field.coerce(document, errors=errors), {
+            "nodeType": "document",
+            "content": []
+        })


### PR DESCRIPTION
Fixed an `IndexError: list assignment index out of range` error in `RichTextField._coerce_block`, which was due to removing items by index from the front of a list causing the indexes to no longer be valid.

If you have a list: `['a', 'b', 'c']` and you want to remove the values at indexes `1` and `2`, if you remove the value at index `1`, then the list size shrinks by one and the index `2` is outside of the list. My fix just does the trimming from the end of the list, so the indexes are still consistent with the size of the list at the time they are removed.