### PR TITLE
Add ResourceLink field to Field Coercion class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Added ResourceLinkg to Field Coercion class
 
 ## v1.13.2
 * Fixed URL to 'Create Issue' button in readme

--- a/contentful/content_type_field_types.py
+++ b/contentful/content_type_field_types.py
@@ -111,6 +111,17 @@ class LinkField(BasicField):
     pass
 
 
+class ResourceLinkField(BasicField):
+    """
+    ResourceLinkField
+
+    Nothing should be done here as ResourceLink does not support entity
+    resolution on the backend side and linked field can’t be used in
+    ordering and filtering queries.
+    """
+    pass
+
+
 class ArrayField(BasicField):
     """Array Coercion Class
 

--- a/contentful/content_type_field_types.py
+++ b/contentful/content_type_field_types.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 try:
     import simplejson as json
 except ImportError:


### PR DESCRIPTION
I have made a change to the library to fix an issue when the customer has enabled cross-space references. Without this change, the library would break because there is no built-in coercion mechanism for the ResourceLink field type to handle these cross-space references.