### PR TITLE
Add to integer coerce support to dict vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # CHANGELOG
+* Added to integer coerce support to dict vars
 
 ## master
 

--- a/contentful/content_type_field_types.py
+++ b/contentful/content_type_field_types.py
@@ -61,7 +61,8 @@ class IntegerField(BasicField):
 
     def coerce(self, value, **kwargs):
         """Coerces value to int"""
-
+        if isinstance(value, dict) and kwargs['default_locale'] in value:
+            return int(value[kwargs['default_locale']])
         return int(value)
 
 


### PR DESCRIPTION
For some reason is trying to coerce in a dict var

![coerce](https://github.com/user-attachments/assets/c1c257cd-4c24-4f4e-a163-86169888d3d5)

`Traceback (most recent call last):
  File "/home/luisricardo/PycharmProjects/pythonProject/get-parent.py", line 46, in <module>
    entries2 = client.entries({'fields.slug': slug,'content_type': 'article'})
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/client.py", line 268, in entries
    return self._get(
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/client.py", line 597, in _get
    ).build()
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource_builder.py", line 61, in build
    return self._build_array()
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource_builder.py", line 82, in _build_array
    items = [self._build_item(
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource_builder.py", line 82, in <listcomp>
    items = [self._build_item(
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource_builder.py", line 112, in _build_item
    return buildables[item['sys']['type']](
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource.py", line 115, in __init__
    self._fields = self._hydrate_fields(item, localized, includes, errors, resources=resources)
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource.py", line 132, in _hydrate_fields
    self._hydrate_non_localized_entry(fields, item, includes, errors, resources)
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/resource.py", line 151, in _hydrate_non_localized_entry
    fields[self._locale()][snake_case(k)] = self._coerce(
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/entry.py", line 68, in _coerce
    return content_type_field.coerce(
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/content_type_field.py", line 39, in coerce
    return self._coercion.coerce(value, **kwargs)
  File "/home/luisricardo/anaconda3/envs/py3-10/lib/python3.10/site-packages/contentful/content_type_field_types.py", line 64, in coerce
    return int(value)
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'dict'`
