### PR TITLE
chore(ci): [SECURITY-1117] Enable CodeQL scans for GitHub workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+---
+name: "CodeQL Scan for GitHub Actions Workflows"
+
+on:
+  push:
+    branches: [master]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: [master]
+    paths: [".github/workflows/**"]
+
+jobs:
+  analyze:
+    name: Analyze GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+
+      - name: Run CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: actions


### PR DESCRIPTION
Enable CodeQL scans for GitHub workflow.

For more details on why we do this, please refer to https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

After the merge, navigate to the code-scanning findings available under the security tab --> code-scanning