### PR TITLE
Fix: Preserve original JSON in entry.raw to prevent non-serializable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## Unreleased
+### Fixed
+- Fixed issue where `entry.raw` contained non-serializable Entry/Link objects, making JSON serialization fail
+
 ### Changed
 - Moved test and docs dependencies to project.optional-dependencies
 - Fixed PDM dependency configuration for CI environment

--- a/contentful/resource.py
+++ b/contentful/resource.py
@@ -35,7 +35,8 @@ class Resource(object):
             resources=None,
             depth=0,
             max_depth=20):
-        self.raw = item
+        import copy
+        self.raw = copy.deepcopy(item)
         self.default_locale = default_locale
         self._depth = depth
         self._max_depth = max_depth


### PR DESCRIPTION
Fixes #92 